### PR TITLE
display the coverage in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ services:
   - docker
 
 script:
-    make docker_up test_integration
+    make docker_up coverage


### PR DESCRIPTION
This PR changes the travis build to display the coverage info from running the integration tests.

An example of it running is here -
https://travis-ci.org/thingful/device-hub/builds/238277619
