### PR TITLE
setting UID on entity

### DIFF
--- a/store/repository.go
+++ b/store/repository.go
@@ -176,6 +176,7 @@ func ensureEntityHasUID(entity *proto.Entity) error {
 
 	switch strings.ToLower(entity.Type) {
 
+	// profile entities should default to the profile-name
 	case "profile":
 
 		if entity.Configuration["profile-name"] != "" {
@@ -183,8 +184,8 @@ func ensureEntityHasUID(entity *proto.Entity) error {
 			// Would be useful for having multiple profiles running
 			// at the same time.
 			entity.Uid = entity.Configuration["profile-name"]
+			return nil
 		}
-
 	}
 
 	hash, err := hash(entity)

--- a/store/repository.go
+++ b/store/repository.go
@@ -60,11 +60,11 @@ func NewRepository(store *Store) *Repository {
 
 func (e *Repository) UpdateOrCreateEntity(item proto.Entity) (string, error) {
 
-	var bucket bucket
+	var b bucket
 
 	switch strings.ToLower(item.Type) {
 	case "listener":
-		bucket = e.Listeners.bucket
+		b = e.Listeners.bucket
 
 		exists := hub.IsListenerRegistered(item.Kind)
 
@@ -73,7 +73,7 @@ func (e *Repository) UpdateOrCreateEntity(item proto.Entity) (string, error) {
 		}
 
 	case "endpoint":
-		bucket = e.Endpoints.bucket
+		b = e.Endpoints.bucket
 
 		exists := hub.IsEndpointRegistered(item.Kind)
 		if !exists {
@@ -81,7 +81,7 @@ func (e *Repository) UpdateOrCreateEntity(item proto.Entity) (string, error) {
 		}
 
 	case "profile":
-		bucket = e.Profiles.bucket
+		b = e.Profiles.bucket
 
 	default:
 		return "", fmt.Errorf("type : %s not registered", item.Type)
@@ -93,7 +93,7 @@ func (e *Repository) UpdateOrCreateEntity(item proto.Entity) (string, error) {
 		return "", err
 	}
 
-	err = e.store.Insert(bucket, []byte(item.Uid), item)
+	err = e.store.Insert(b, []byte(item.Uid), item)
 
 	if err != nil {
 		return "", err

--- a/store/repository.go
+++ b/store/repository.go
@@ -186,17 +186,18 @@ func ensureEntityHasUID(entity *proto.Entity) error {
 			entity.Uid = entity.Configuration["profile-name"]
 			return nil
 		}
+	default:
+		hash, err := hash(entity)
+
+		if err != nil {
+			return err
+		}
+
+		entity.Uid = string(hash)
+		return nil
+
 	}
-
-	hash, err := hash(entity)
-
-	if err != nil {
-		return err
-	}
-
-	entity.Uid = string(hash)
 	return nil
-
 }
 
 func hash(data interface{}) ([]byte, error) {

--- a/store/repository_test.go
+++ b/store/repository_test.go
@@ -1,8 +1,66 @@
 package store
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thingful/device-hub/proto"
+)
 
 func TestUIDIsSetOnEntity(t *testing.T) {
 	t.Parallel()
 
+	listener := &proto.Entity{Type: "listener"}
+	endpoint := &proto.Entity{Type: "endpoint"}
+	profile := &proto.Entity{Type: "profile"}
+
+	err := ensureEntityHasUID(listener)
+	assert.Nil(t, err)
+
+	err = ensureEntityHasUID(endpoint)
+	assert.Nil(t, err)
+
+	err = ensureEntityHasUID(profile)
+	assert.Nil(t, err)
+
+	// uids shouldn't be equal
+	assert.NotEqual(t, listener.Uid, endpoint.Uid)
+	assert.NotEqual(t, endpoint.Uid, profile.Uid)
+	assert.NotEqual(t, profile.Uid, listener.Uid)
+}
+
+func TestUIDIsNotSetOnEntity(t *testing.T) {
+	t.Parallel()
+
+	listener := &proto.Entity{Type: "listener", Uid: "foo"}
+	endpoint := &proto.Entity{Type: "endpoint", Uid: "bar"}
+	profile := &proto.Entity{Type: "profile", Uid: "foobar"}
+
+	err := ensureEntityHasUID(listener)
+	assert.Nil(t, err)
+
+	err = ensureEntityHasUID(endpoint)
+	assert.Nil(t, err)
+
+	err = ensureEntityHasUID(profile)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "foo", listener.Uid)
+	assert.Equal(t, "bar", endpoint.Uid)
+	assert.Equal(t, "foobar", profile.Uid)
+}
+
+func TestProfileUidDefaultsToProfileName(t *testing.T) {
+	t.Parallel()
+
+	profile := &proto.Entity{
+		Type: "profile",
+		Configuration: map[string]string{
+			"profile-name": "foobar",
+		}}
+
+	err := ensureEntityHasUID(profile)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "foobar", profile.Uid)
 }

--- a/store/repository_test.go
+++ b/store/repository_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2017 thingful
+
 package store
 
 import (

--- a/store/repository_test.go
+++ b/store/repository_test.go
@@ -1,0 +1,8 @@
+package store
+
+import "testing"
+
+func TestUIDIsSetOnEntity(t *testing.T) {
+	t.Parallel()
+
+}

--- a/store/repository_test.go
+++ b/store/repository_test.go
@@ -50,7 +50,7 @@ func TestUIDIsNotSetOnEntity(t *testing.T) {
 	assert.Equal(t, "foobar", profile.Uid)
 }
 
-func TestProfileUidDefaultsToProfileName(t *testing.T) {
+func TestProfileUIDDefaultsToProfileName(t *testing.T) {
 	t.Parallel()
 
 	profile := &proto.Entity{

--- a/store/store.go
+++ b/store/store.go
@@ -50,9 +50,6 @@ func (s *Store) MustCreateBuckets(buckets []bucket) {
 
 }
 
-func mustCreateBucket(tx *bolt.Tx, bucket bucket) {
-}
-
 func (s *Store) Insert(bucket bucket, uid []byte, data interface{}) error {
 
 	err := s.db.Update(func(tx *bolt.Tx) error {


### PR DESCRIPTION
This PR tidies up the logic around setting UIDs on entities
- use the UID if provided
- if none is specified and it is a profile use the profile name
- for other types calculate the hash only if required

The initial bug was found on the grove-pi branch,