### PR TITLE
bindings are not Urls

### DIFF
--- a/describe/describe.go
+++ b/describe/describe.go
@@ -4,6 +4,7 @@ package describe
 
 import (
 	"fmt"
+	"net/url"
 	"sync"
 
 	"github.com/asaskevich/govalidator"
@@ -273,20 +274,26 @@ func (v Values) Int64(key string) (int64, bool) {
 }
 
 // Url returns a Url and true if a value exists and can be cast to an url
-func (v Values) Url(key string) (string, bool) {
+func (v Values) Url(key string) (*url.URL, bool) {
 
 	value, found := v.String(key)
 
 	if !found {
-		return "", false
+		return nil, false
 	}
 
 	valid := govalidator.IsRequestURL(value)
 	if !valid {
-		return "", false
+		return nil, false
 	}
 
-	return value, true
+	url, err := url.Parse(value)
+
+	if err != nil {
+		return nil, false
+	}
+
+	return url, true
 
 }
 

--- a/describe/describe_test.go
+++ b/describe/describe_test.go
@@ -113,6 +113,30 @@ func TestNewValues_InvalidURL(t *testing.T) {
 
 }
 
+func TestNewValues_ValidURL(t *testing.T) {
+
+	t.Parallel()
+
+	config := map[string]string{
+		"a-url": "tcp://0.0.0.0:8080",
+	}
+
+	params := Parameters{
+		Parameter{Name: "a-url", Type: Url, Required: true},
+	}
+
+	values, err := NewValues(config, params)
+
+	assert.Nil(t, err)
+
+	url, ok := values.Url("a-url")
+
+	assert.True(t, ok)
+
+	assert.Equal(t, url.Scheme, "tcp")
+
+}
+
 func TestFloat32(t *testing.T) {
 
 	t.Parallel()

--- a/describe/describe_test.go
+++ b/describe/describe_test.go
@@ -129,12 +129,9 @@ func TestNewValues_ValidURL(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	url, ok := values.Url("a-url")
+	_, ok := values.Url("a-url")
 
 	assert.True(t, ok)
-
-	assert.Equal(t, url.Scheme, "tcp")
-
 }
 
 func TestFloat32(t *testing.T) {

--- a/listener/listeners.go
+++ b/listener/listeners.go
@@ -18,7 +18,7 @@ func init() {
 		Name:        "mqtt-broker-address",
 		Type:        describe.Url,
 		Required:    true,
-		Description: "address to bind to",
+		Description: "address to connect to",
 		Examples:    []string{"tcp://0.0.0.0:1883"},
 	}
 
@@ -92,10 +92,10 @@ func init() {
 
 	http_bindingAddress := describe.Parameter{
 		Name:        "http-binding-address",
-		Type:        describe.Url,
+		Type:        describe.String,
 		Required:    true,
 		Description: "address to bind to",
-		Examples:    []string{"tcp://0.0.0.0:9090", "tcp://*:9090"},
+		Examples:    []string{"0.0.0.0:9090", "*:9090", ":8000"},
 	}
 
 	hub.RegisterListener("http",

--- a/test-configurations/http_listener.yaml
+++ b/test-configurations/http_listener.yaml
@@ -4,4 +4,4 @@ type: listener
 kind: http
 configuration:
   # Address to receive messages from 
-    http-binding-address: tcp://0.0.0.0:8085
+    http-binding-address: 0.0.0.0:8085


### PR DESCRIPTION
This PR -
- amends the Url( key string) method to return a net.URL rather than a string
- changes the description of the http listener to expect a describe.String rather than a describe.URL as this what the golang http package expects. 