### PR TITLE
create -d parameter

### DIFF
--- a/cmd/device-hub-cli/helpers.go
+++ b/cmd/device-hub-cli/helpers.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/fiorix/protoc-gen-cobra/iocodec"
@@ -160,7 +161,8 @@ func roundTrip(sample interface{}, fn roundTripFunc) error {
 
 			fmt.Println(fi.Name())
 
-			f, d, err := decoderFromPath(cfg.RequestDir + fi.Name())
+			folderPath := path.Join(cfg.RequestDir, fi.Name())
+			f, d, err := decoderFromPath(folderPath)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR addresses #39 using the path library rather than string concatenation to join paths.
