### PR TITLE
allow only yaml files to be used for configuration

### DIFF
--- a/cmd/device-hub-cli/helpers.go
+++ b/cmd/device-hub-cli/helpers.go
@@ -209,13 +209,13 @@ func decoderFromPath(filePath string) (*os.File, iocodec.Decoder, error) {
 
 	if len(ext) > 0 && ext[0] == '.' {
 		ext = ext[1:]
+		if ext != "yaml" {
+			return nil, nil, fmt.Errorf("invalid request file format: %q", ext)
+
+		}
 	}
 
-	dm, ok := iocodec.DefaultDecoders[ext]
-
-	if !ok {
-		return nil, nil, fmt.Errorf("invalid request file format: %q", ext)
-	}
+	dm, _ := iocodec.DefaultDecoders["yaml"]
 
 	return f, dm.NewDecoder(f), nil
 }

--- a/cmd/device-hub-cli/main.go
+++ b/cmd/device-hub-cli/main.go
@@ -52,10 +52,10 @@ func newConfig() *config {
 
 func (o *config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.ServerAddr, "server-addr", "s", o.ServerAddr, "server address in form of host:port")
-	fs.StringVarP(&o.RequestFile, "request-file", "f", o.RequestFile, "client request file (must be json, yaml, or xml); use \"-\" for stdin + json")
-	fs.StringVarP(&o.RequestDir, "request-dir", "d", o.RequestDir, "directory containing client request file(s) (must be json, yaml, or xml)")
+	fs.StringVarP(&o.RequestFile, "request-file", "f", o.RequestFile, "client request file (must be yaml); use \"-\" for stdin + json")
+	fs.StringVarP(&o.RequestDir, "request-dir", "d", o.RequestDir, "directory containing client request file(s) (must be yaml)")
 	fs.BoolVarP(&o.PrintSampleRequest, "print-sample-request", "p", o.PrintSampleRequest, "print sample request file and exit")
-	fs.StringVarP(&o.ResponseFormat, "response-format", "o", o.ResponseFormat, "response format (json, prettyjson, yaml, or xml)")
+	fs.StringVarP(&o.ResponseFormat, "response-format", "o", o.ResponseFormat, "response format (json, prettyjson or yaml)")
 	fs.DurationVar(&o.Timeout, "timeout", o.Timeout, "client connection timeout")
 	fs.BoolVar(&o.TLS, "tls", o.TLS, "enable tls")
 	fs.StringVar(&o.ServerName, "tls-server-name", o.ServerName, "tls server name override")


### PR DESCRIPTION
This PR removes support for json and xml configuration meaning the cli only supports YAML files.

Support for JSON and XML was broken anyway but I think YAML is a bit more concise than XML and allows commenting unlike JSON,

