### PR TITLE
Vendor licensing check

### DIFF
--- a/.licenses.yaml
+++ b/.licenses.yaml
@@ -1,0 +1,11 @@
+accepted:
+- MIT
+- Apache-2.0
+- NewBSD
+
+unaccepted:
+- GPL-2.0
+- GPL-3.0
+
+exceptions:
+- github.com/davecgh/go-spew # Uses ISC license (https://opensource.org/licenses/ISC)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ sudo: required
 services:
   - docker
 
+before_script:
+  - go get github.com/chespinoza/goliscan
+  
 script:
   - make check-license
+  - make check-vendor-licenses
   - make docker_up coverage
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ check-license: ## check the license header in every code file
 
 .PHONY: check-license
 
+check-vendor-licenses: ## check if licenses of project dependencies meet project requirements 
+	@goliscan check --direct-only
+	@goliscan check --indirect-only
+.PHONY: check-vendor-licenses
+
 test: ## run tests
 	$(GO_TEST) $(PACKAGES)
 


### PR DESCRIPTION
- Added checks to makefile and build pipeline using goliscan tool to check direct and indirect dependencies.
- Added required config file .licenses.yaml to specify checks with the next configuration:

accepted:
- MIT
- Apache-2.0
- NewBSD

unaccepted:
- GPL-2.0
- GPL-3.0

exceptions:
- github.com/davecgh/go-spew # Uses ISC license (https://opensource.org/licenses/ISC)