### PR TITLE
Flake test statistics on channel out

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -27,9 +27,15 @@ func (m *Channel) Close() error {
 // Endpoint allows to create a mock Endpoint
 // Implements hub.Endpoint
 type Endpoint struct {
-	Error error
+	Writer func(message hub.Message) error
+	Error  error
 }
 
 func (e *Endpoint) Write(message hub.Message) error {
+
+	if e.Writer != nil {
+		return e.Writer(message)
+	}
+
 	return e.Error
 }

--- a/runtime/loop_test.go
+++ b/runtime/loop_test.go
@@ -91,7 +91,7 @@ func TestStatisticsOnChannelOut(t *testing.T) {
 		ErrorChannel:   make(chan error),
 		MessageChannel: messageChannel,
 		Closer: func() error {
-			wg.Done()
+			defer wg.Done()
 			return nil
 		},
 	}


### PR DESCRIPTION
This PR should hopefully fix #83 (although I said that last time as well!)

To test-

```
cd ./runtime
go test -count 1000000
```

I ran it 1 000 000 times on my machine (multiple times) but as to the nature of the failure maybe this guarantees nothing! Each run takes about 3 minutes.
