### PR TITLE
Server config file

### DIFF
--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -84,7 +84,6 @@ var serverCommand = &cobra.Command{
 			return err
 		}
 
-		fmt.Println(_config)
 		err = server.Serve(server.Options{
 			Binding:           _config.Binding,
 			UseTLS:            _config.TLS,

--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -23,13 +23,6 @@ import (
 var serverCommand = &cobra.Command{
 	Use:   "server",
 	Short: "Start device hub.",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Load Config File if is enabled
-		if _config.ConfigFile {
-			_config.AddConfigFile(_config.ConfigPath)
-
-		}
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		ctx := context.Background()

--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"path"
 	"strings"
 
@@ -28,6 +29,12 @@ var serverCommand = &cobra.Command{
 		ctx := context.Background()
 
 		var dataImpl store.Storer
+
+		// Load Config File if is enabled
+		if _config.ConfigFile {
+			log.Println("Overriding all settings with config file")
+			_config.AddConfigFile(_config.ConfigPath)
+		}
 
 		switch strings.ToLower(_config.DataImpl) {
 		case "boltdb":
@@ -77,6 +84,7 @@ var serverCommand = &cobra.Command{
 			return err
 		}
 
+		fmt.Println(_config)
 		err = server.Serve(server.Options{
 			Binding:           _config.Binding,
 			UseTLS:            _config.TLS,

--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -23,16 +23,18 @@ import (
 var serverCommand = &cobra.Command{
 	Use:   "server",
 	Short: "Start device hub.",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Load Config File if is enabled
+		if _config.ConfigFile {
+			_config.AddConfigFile(_config.ConfigPath)
+
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		ctx := context.Background()
 
 		var dataImpl store.Storer
-
-		// Load Config File if is enabled
-		if _config.ConfigFile {
-			_config.AddConfigFile(_config.ConfigPath)
-		}
 
 		switch strings.ToLower(_config.DataImpl) {
 		case "boltdb":

--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 	"strings"
 
@@ -32,7 +31,6 @@ var serverCommand = &cobra.Command{
 
 		// Load Config File if is enabled
 		if _config.ConfigFile {
-			log.Println("Overriding all settings with config file")
 			_config.AddConfigFile(_config.ConfigPath)
 		}
 

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -29,19 +29,19 @@ const _ = grpc.SupportPackageIsVersion4
 var _config = newConfig()
 
 type config struct {
-	Binding    string `envconfig:"BINDING" default:":50051" yaml:"binding,omitempty"`
-	TLS        bool   `envconfig:"TLS" yaml:"tls,omitempty"`
-	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"tls_server_name,omitempty"`
-	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"tls_ca_cert_file,omitempty"`
-	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"tls_cert_file,omitempty"`
-	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"tls_key_file,omitempty"`
-	DataDir    string `envconfig:"DATA_DIR" default:"." yaml:"data_dir,omitempty"`
-	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl,omitempty"`
-	LogFile    bool   `envconfig:"LOG_FILE" yaml:"log_file,omitempty"`
-	LogPath    string `envconfig:"LOG_PATH" default:"./device-hub.log" yaml:"log_path,omitempty"`
-	Syslog     bool   `envconfig:"LOG_SYSLOG" yaml:"sys_log,omitempty"`
-	ConfigFile bool   `envconfig:"CONFIG_FILE"`
-	ConfigPath string `envconfig:"CONFIG_PATH" default:"./config.yaml"`
+	Binding    string `envconfig:"BINDING" default:":50051" yaml:"binding"`
+	TLS        bool   `envconfig:"TLS" yaml:"tls"`
+	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"tls_server_name"`
+	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"tls_ca_cert_file"`
+	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"tls_cert_file"`
+	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"tls_key_file"`
+	DataDir    string `envconfig:"DATA_DIR" default:"." yaml:"data_dir"`
+	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl"`
+	LogFile    bool   `envconfig:"LOG_FILE" yaml:"log_file"`
+	LogPath    string `envconfig:"LOG_PATH" default:"./device-hub.log" yaml:"log_path"`
+	Syslog     bool   `envconfig:"LOG_SYSLOG" yaml:"sys_log"`
+	ConfigFile bool   `envconfig:"CONFIG_FILE" yaml:"-"`
+	ConfigPath string `envconfig:"CONFIG_PATH" default:"./config.yaml" yaml:"-"`
 }
 
 func newConfig() *config {
@@ -67,6 +67,7 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *config) AddConfigFile(cf string) {
+	var readFields interface{}
 	content, err := ioutil.ReadFile(cf)
 	if err != nil {
 		log.Fatalf("Failed to read config file config.yaml: %s\n", err.Error())
@@ -76,6 +77,24 @@ func (o *config) AddConfigFile(cf string) {
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s\n", err.Error())
 	}
+
+	err = yaml.Unmarshal(content, &readFields)
+	if err != nil {
+		log.Fatalf("Error parsing config file: %s\n", err.Error())
+	}
+
+	keys := make([]string, 0)
+
+	if fields, ok := (readFields).(map[interface{}]interface{}); ok {
+		for k, _ := range fields {
+			if s, ok := k.(string); ok {
+				keys = append(keys, s)
+			}
+		}
+		log.Printf("Overriding keys: %v with config file\n", keys)
+		return
+	}
+	log.Println("No fields overriden")
 }
 
 func init() {

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -67,7 +67,9 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *config) AddConfigFile(cf string) {
-	var readFields interface{}
+
+	var readFields map[string]interface{}
+
 	content, err := ioutil.ReadFile(cf)
 	if err != nil {
 		log.Fatalf("Failed to read config file config.yaml: %s\n", err.Error())
@@ -85,16 +87,10 @@ func (o *config) AddConfigFile(cf string) {
 
 	keys := make([]string, 0)
 
-	if fields, ok := (readFields).(map[interface{}]interface{}); ok {
-		for k, _ := range fields {
-			if s, ok := k.(string); ok {
-				keys = append(keys, s)
-			}
-		}
-		log.Printf("Overriding keys: %v with config file\n", keys)
-		return
+	for k, _ := range readFields {
+		keys = append(keys, k)
 	}
-	log.Println("No fields overridden")
+	log.Printf("Overriding keys: %v with config file\n", keys)
 }
 
 func init() {

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -58,7 +58,7 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KeyFile, "tls-key-file", o.KeyFile, "client key file")
 	fs.StringVar(&o.DataDir, "data-dir", o.DataDir, "path to db folder, defaults to current directory")
 	fs.StringVar(&o.DataImpl, "data-impl", o.DataImpl, "datastore to use, valid values are 'boltdb' or 'filestore', defaults to boltdb")
-	fs.BoolVar(&o.LogFile, "log-file", o.LogFile, "enable log to file")
+	fs.BoolVarP(&o.LogFile, "log-file", "l", o.LogFile, "enable log to file")
 	fs.StringVar(&o.LogPath, "log-path", o.LogPath, "path to log file, defaults to ./device-hub.log")
 	fs.BoolVar(&o.Syslog, "log-syslog", o.Syslog, "enable log to local SYSLOG")
 	fs.BoolVarP(&o.ConfigFile, "config-file", "c", o.ConfigFile, "enable config file overriding flags and env vars")
@@ -82,10 +82,6 @@ func init() {
 	RootCmd.AddCommand(versionCommand)
 	RootCmd.AddCommand(serverCommand)
 	_config.AddFlags(RootCmd.PersistentFlags())
-	if _config.ConfigFile {
-		log.Println("Overriding settings with config file")
-		_config.AddConfigFile(_config.ConfigPath)
-	}
 }
 
 func main() {

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"io/ioutil"
+	"log"
 	"os"
 
 	"google.golang.org/grpc"
@@ -10,6 +12,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
 
 	_ "github.com/thingful/device-hub/endpoint"
 	_ "github.com/thingful/device-hub/listener"
@@ -26,17 +29,19 @@ const _ = grpc.SupportPackageIsVersion4
 var _config = newConfig()
 
 type config struct {
-	Binding    string `envconfig:"BINDING" default:":50051"`
-	TLS        bool   `envconfig:"TLS"`
-	ServerName string `envconfig:"TLS_SERVER_NAME"`
-	CACertFile string `envconfig:"TLS_CA_CERT_FILE"`
-	CertFile   string `envconfig:"TLS_CERT_FILE"`
-	KeyFile    string `envconfig:"TLS_KEY_FILE"`
-	DataDir    string `envconfig:"DATA_DIR" default:"."`
-	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb"`
-	LogFile    bool   `envconfig:"LOG_FILE"`
-	LogPath    string `envconfig:"LOG_PATH" default:"./device-hub.log"`
-	Syslog     bool   `envconfig:"LOG_SYSLOG"`
+	Binding    string `envconfig:"BINDING" default:":50051" yaml:"binding,omitempty"`
+	TLS        bool   `envconfig:"TLS" yaml:"tls,omitempty"`
+	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"server_name,omitempty"`
+	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"ca_cert_file,omitempty"`
+	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"cert_file,omitempty"`
+	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"key_file,omitempty"`
+	DataDir    string `envconfig:"DATA_DIR" default:"." yaml:"data_dir,omitempty"`
+	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl,omitempty"`
+	LogFile    bool   `envconfig:"LOG_FILE" yaml:"log_file,omitempty"`
+	LogPath    string `envconfig:"LOG_PATH" default:"./device-hub.log" yaml:"log_path,omitempty"`
+	Syslog     bool   `envconfig:"LOG_SYSLOG" yaml:"sys_log,omitempty"`
+	ConfigFile bool   `envconfig:"CONFIG_FILE"`
+	ConfigPath string `envconfig:"CONFIG_PATH" default:"./config.yaml"`
 }
 
 func newConfig() *config {
@@ -56,12 +61,30 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.LogFile, "log-file", o.LogFile, "enable log to file")
 	fs.StringVar(&o.LogPath, "log-path", o.LogPath, "path to log file, defaults to ./device-hub.log")
 	fs.BoolVar(&o.Syslog, "log-syslog", o.Syslog, "enable log to local SYSLOG")
+	fs.BoolVar(&o.ConfigFile, "config-file", o.ConfigFile, "enable config file overriding flags and env vars")
+	fs.StringVar(&o.ConfigPath, "config-path", o.ConfigPath, "path to config file, defaults to ./config.yaml")
+}
+
+func (o *config) AddConfigFile(cf string) {
+	content, err := ioutil.ReadFile(cf)
+	if err != nil {
+		log.Fatalf("Failed to read config file config.yaml: %s\n", err.Error())
+	}
+	// TODO check & test nontags fields!!!!!
+	err = yaml.Unmarshal(content, &o)
+	if err != nil {
+		log.Fatalf("Error parsing config file: %s\n", err.Error())
+	}
 }
 
 func init() {
 	RootCmd.AddCommand(versionCommand)
 	RootCmd.AddCommand(serverCommand)
 	_config.AddFlags(RootCmd.PersistentFlags())
+	if _config.ConfigFile {
+		log.Println("Overriding settings with config file")
+		_config.AddConfigFile(_config.ConfigPath)
+	}
 }
 
 func main() {

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -20,6 +20,13 @@ import (
 
 var RootCmd = &cobra.Command{
 	Use: "device-hub",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Load Config File if is enabled
+		if _config.ConfigFile {
+			_config.AddConfigFile(_config.ConfigPath)
+
+		}
+	},
 }
 
 // This is a compile-time assertion to ensure that this generated file

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -94,7 +94,7 @@ func (o *config) AddConfigFile(cf string) {
 		log.Printf("Overriding keys: %v with config file\n", keys)
 		return
 	}
-	log.Println("No fields overriden")
+	log.Println("No fields overridden")
 }
 
 func init() {

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -31,10 +31,10 @@ var _config = newConfig()
 type config struct {
 	Binding    string `envconfig:"BINDING" default:":50051" yaml:"binding,omitempty"`
 	TLS        bool   `envconfig:"TLS" yaml:"tls,omitempty"`
-	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"server_name,omitempty"`
-	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"ca_cert_file,omitempty"`
-	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"cert_file,omitempty"`
-	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"key_file,omitempty"`
+	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"tls_server_name,omitempty"`
+	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"tls_ca_cert_file,omitempty"`
+	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"tls_cert_file,omitempty"`
+	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"tls_key_file,omitempty"`
 	DataDir    string `envconfig:"DATA_DIR" default:"." yaml:"data_dir,omitempty"`
 	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl,omitempty"`
 	LogFile    bool   `envconfig:"LOG_FILE" yaml:"log_file,omitempty"`
@@ -61,8 +61,9 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.LogFile, "log-file", o.LogFile, "enable log to file")
 	fs.StringVar(&o.LogPath, "log-path", o.LogPath, "path to log file, defaults to ./device-hub.log")
 	fs.BoolVar(&o.Syslog, "log-syslog", o.Syslog, "enable log to local SYSLOG")
-	fs.BoolVar(&o.ConfigFile, "config-file", o.ConfigFile, "enable config file overriding flags and env vars")
+	fs.BoolVarP(&o.ConfigFile, "config-file", "c", o.ConfigFile, "enable config file overriding flags and env vars")
 	fs.StringVar(&o.ConfigPath, "config-path", o.ConfigPath, "path to config file, defaults to ./config.yaml")
+	fs.Parse(os.Args)
 }
 
 func (o *config) AddConfigFile(cf string) {
@@ -70,7 +71,7 @@ func (o *config) AddConfigFile(cf string) {
 	if err != nil {
 		log.Fatalf("Failed to read config file config.yaml: %s\n", err.Error())
 	}
-	// TODO check & test nontags fields!!!!!
+
 	err = yaml.Unmarshal(content, &o)
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s\n", err.Error())

--- a/docs/server.md
+++ b/docs/server.md
@@ -23,6 +23,15 @@ CLI Commands
 CLI Global Flags
 =================
 ```
+- Flag:           -c
+  Large Format:   --config-file
+  Description:    Enable config file, fields in config file will override flags and env vars
+  Default:        false
+
+- Flag:           --config-path
+  Description:    Path to config file
+  Default:        ./config.yaml
+
 - Flag:           -b
   Large Format:   --binding <string>
   Description:    Binding address in form of {ip}:port

--- a/examples/server_config/config.yaml
+++ b/examples/server_config/config.yaml
@@ -1,0 +1,11 @@
+binding: ":50052"
+tls: true
+tls_server_name: 127.0.0.1
+tls_ca_cert_file: ../../../examples/certs/My_Root_CA.crt
+tls_cert_file: ../../../examples/certs/127.0.0.1.crt
+tls_key_file: ../../../examples/certs/127.0.0.1.key
+data_dir: .
+data_impl: boltdb
+log_file: true
+log_path: custom_log.log
+sys_log: false

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Start the device-hub server, the server instance can be customized with env vars
 ```
 Client
 ------
-With the client you can load [settings]( https://github.com/thingful/device-hub/blob/master/docs/client.md#client-cli ) to the server instance.
+The device-hub client [configures]( https://github.com/thingful/device-hub/blob/master/docs/client.md#client-cli ) the server instance.
 
 To import a folder of configuration files
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Build
 
 Install golang, docker (if you want to run the integration tests or test with a local mqtt server)
 
-Get the code -
+Get the code
 
 ```
 go get github.com/thingful/device-hub
@@ -101,16 +101,21 @@ make all
 
 Output is built to ./tmp/build/
 
-Run
+Run the Server
 ---
 
-Start the device-hub server
+Start the device-hub server, the server instance can be customized with env vars, flags or a config file, the precedence order is:
+<br>
+```Config File > Flags > Env Vars```
+<br>
+ [More init configuration info.]( https://github.com/thingful/device-hub/blob/master/docs/server.md#cli-global-flags )
 
 ```
 ./device-hub server
 ```
-
-Configure with the client
+Client
+------
+With the client you can load [settings]( https://github.com/thingful/device-hub/blob/master/docs/client.md#client-cli ) to the server instance.
 
 To import a folder of configuration files
 

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/thingful/device-hub/proto"
 	"github.com/thingful/device-hub/runtime"
 
+	"log"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
@@ -78,7 +80,7 @@ func Serve(options Options, manager *runtime.Manager) error {
 	reflection.Register(grpcServer)
 
 	listener, err := net.Listen("tcp", options.Binding)
-
+	log.Printf("Listening on: [%v]\n", options.Binding)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
Added config file feature mentioned on #77
Example config file added to `/examples/server_config/config.yaml`
Default location for the config file: `./config.yaml`
Config Priority: `Config file > Flags > Env Vars`

how to use with the current sample config file:
Server:

> ./device-hub server -c --config-path=../../../examples/server_config/config.yaml

Client:

> ./device-hub-cli -s=127.0.0.1:50052 --tls --tls-ca-cert-file=../../../examples/certs/My_Root_CA.crt --tls-cert-file=../../../examples/certs/127.0.0.1.crt --tls-key-file=../../../examples/certs/127.0.0.1.key status | jq