### PR TITLE
Device hub server - JS engine - geo location passed using configuration

### DIFF
--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -57,14 +57,14 @@ var serverCommand = &cobra.Command{
 
 		repository := store.NewRepository(dataImpl, register)
 
-		options := make(map[string]interface{})
+		options := runtime.Options{}
 
 		if _config.GeoEnabled {
-			options["geolocation"] = true
-			options["lat"] = _config.GeoLat
-			options["lng"] = _config.GeoLng
+			options.GeoEnabled = true
+			options.GeoLat = _config.GeoLat
+			options.GeoLng = _config.GeoLng
 		} else {
-			options["geolocation"] = false
+			options.GeoEnabled = false
 		}
 
 		manager, err := runtime.NewEndpointManager(ctx,

--- a/cmd/device-hub/cmd_server.go
+++ b/cmd/device-hub/cmd_server.go
@@ -57,13 +57,25 @@ var serverCommand = &cobra.Command{
 
 		repository := store.NewRepository(dataImpl, register)
 
+		options := make(map[string]interface{})
+
+		if _config.GeoEnabled {
+			options["geolocation"] = true
+			options["lat"] = _config.GeoLat
+			options["lng"] = _config.GeoLng
+		} else {
+			options["geolocation"] = false
+		}
+
 		manager, err := runtime.NewEndpointManager(ctx,
 			repository,
 			register,
 			utils.NewLogger(hub.DaemonVersionString(),
 				_config.Syslog,
 				_config.LogFile,
-				_config.LogPath))
+				_config.LogPath),
+			options,
+		)
 
 		if err != nil {
 			return err

--- a/cmd/device-hub/main.go
+++ b/cmd/device-hub/main.go
@@ -36,19 +36,22 @@ const _ = grpc.SupportPackageIsVersion4
 var _config = newConfig()
 
 type config struct {
-	Binding    string `envconfig:"BINDING" default:":50051" yaml:"binding"`
-	TLS        bool   `envconfig:"TLS" yaml:"tls"`
-	ServerName string `envconfig:"TLS_SERVER_NAME" yaml:"tls_server_name"`
-	CACertFile string `envconfig:"TLS_CA_CERT_FILE" yaml:"tls_ca_cert_file"`
-	CertFile   string `envconfig:"TLS_CERT_FILE" yaml:"tls_cert_file"`
-	KeyFile    string `envconfig:"TLS_KEY_FILE" yaml:"tls_key_file"`
-	DataDir    string `envconfig:"DATA_DIR" default:"." yaml:"data_dir"`
-	DataImpl   string `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl"`
-	LogFile    bool   `envconfig:"LOG_FILE" yaml:"log_file"`
-	LogPath    string `envconfig:"LOG_PATH" default:"./device-hub.log" yaml:"log_path"`
-	Syslog     bool   `envconfig:"LOG_SYSLOG" yaml:"sys_log"`
-	ConfigFile bool   `envconfig:"CONFIG_FILE" yaml:"-"`
-	ConfigPath string `envconfig:"CONFIG_PATH" default:"./config.yaml" yaml:"-"`
+	Binding    string  `envconfig:"BINDING" default:":50051" yaml:"binding"`
+	TLS        bool    `envconfig:"TLS" yaml:"tls"`
+	ServerName string  `envconfig:"TLS_SERVER_NAME" yaml:"tls_server_name"`
+	CACertFile string  `envconfig:"TLS_CA_CERT_FILE" yaml:"tls_ca_cert_file"`
+	CertFile   string  `envconfig:"TLS_CERT_FILE" yaml:"tls_cert_file"`
+	KeyFile    string  `envconfig:"TLS_KEY_FILE" yaml:"tls_key_file"`
+	DataDir    string  `envconfig:"DATA_DIR" default:"." yaml:"data_dir"`
+	DataImpl   string  `envconfig:"DATA_IMPL" default:"boltdb" yaml:"data_impl"`
+	LogFile    bool    `envconfig:"LOG_FILE" yaml:"log_file"`
+	LogPath    string  `envconfig:"LOG_PATH" default:"./device-hub.log" yaml:"log_path"`
+	Syslog     bool    `envconfig:"LOG_SYSLOG" yaml:"sys_log"`
+	ConfigFile bool    `envconfig:"CONFIG_FILE" yaml:"-"`
+	ConfigPath string  `envconfig:"CONFIG_PATH" default:"./config.yaml" yaml:"-"`
+	GeoEnabled bool    `envconfig:"GEO_ENABLED" yaml:"geo_enabled"`
+	GeoLat     float64 `envconfig:"GEO_LAT" yaml:"geo_lat"`
+	GeoLng     float64 `envconfig:"GEO_LNG" yaml:"geo_lng"`
 }
 
 func newConfig() *config {
@@ -70,6 +73,9 @@ func (o *config) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.Syslog, "log-syslog", o.Syslog, "enable log to local SYSLOG")
 	fs.BoolVarP(&o.ConfigFile, "config-file", "c", o.ConfigFile, "enable config file overriding flags and env vars")
 	fs.StringVar(&o.ConfigPath, "config-path", o.ConfigPath, "path to config file, defaults to ./config.yaml")
+	fs.BoolVar(&o.GeoEnabled, "geo-enabled", o.GeoEnabled, "enable geo location")
+	fs.Float64Var(&o.GeoLat, "geo-lat", o.GeoLat, "device-hub geo latitude")
+	fs.Float64Var(&o.GeoLng, "geo-lng", o.GeoLng, "device-hub geo longitude")
 	fs.Parse(os.Args)
 }
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -57,6 +57,18 @@ CLI Global Flags
   Description:    enable log to local SYSLOG
   Default:        false
 
+- Flag:           --geo-enabled
+  Description:    enable pass fixed geolocation coordinates to JS engine 
+  Default:        false
+
+- Flag:           --geo-lat
+  Description:    geographic latitude in decimal degrees (i.e: 54.416333)
+  Default:        0
+
+  - Flag:           --geo-lng
+  Description:    geographic longitude in decimal degrees (i.e: -4.36552)
+  Default:        0
+
 ```
 CLI Global TLS Security Flags
 =============================

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -147,6 +147,12 @@ func (e engine) run(code, main string, env map[string]interface{}, timeout time.
 	return vm.Run(fmt.Sprintf("%s;\n %s", code, main))
 }
 
+func (e engine) SetGeoLocation(lat, lng float64) {
+	pos := new(position)
+	pos.setLocation(lat, lng)
+	e.AuxObjs["geolocation"] = pos
+}
+
 func prepareCSV(input hub.Message) (map[string]interface{}, error) {
 
 	r := csv.NewReader(strings.NewReader(string(input.Payload)))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -31,7 +31,8 @@ func New(logger utils.Logger) engine {
 }
 
 type engine struct {
-	logger utils.Logger
+	logger   utils.Logger
+	auxFuncs map[string]func(otto.FunctionCall) otto.Value
 }
 
 // Execute takes a script and a message - like a method and function arguments
@@ -102,6 +103,11 @@ func (e engine) run(code, main string, env map[string]interface{}, timeout time.
 		return otto.UndefinedValue()
 	})
 	vm.Run("console.log = __log")
+
+	// Set aux functions
+	for fname, f := range e.auxFuncs {
+		vm.Set(fname, f)
+	}
 
 	defer func() {
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5,7 +5,6 @@ package engine
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"testing"
 	"time"
 
@@ -103,37 +102,6 @@ func TestJSONDecodeValid(t *testing.T) {
 
 	assert.NotNil(t, resultAsMap["a"])
 	assert.Equal(t, resultAsMap["a"], float64(1))
-}
-
-func TestEngineAuxFunction_(t *testing.T) {
-
-	t.Parallel()
-
-	script := Script{
-		Main:    "xxx",
-		Runtime: Javascript,
-		Input:   JSON,
-		Contents: `function xxx (input) {
-				return test(input.a)
-			}`,
-	}
-
-	json := "{ \"a\" : 1}"
-	input := hub.Message{Payload: []byte(json), Metadata: map[string]interface{}{}}
-
-	e := New(utils.NewNoOpLogger())
-
-	e.AuxFuncs["test"] = func(call otto.FunctionCall) otto.Value {
-		i := call.Argument(0)
-		val, _ := otto.ToValue(i)
-
-		return val
-	}
-	result, err := e.Execute(script, input)
-
-	assert.Nil(t, err)
-
-	fmt.Println(result.Output)
 }
 
 func TestEngineAuxFunction(t *testing.T) {

--- a/engine/geolocation.go
+++ b/engine/geolocation.go
@@ -1,0 +1,25 @@
+// Copyright © 2017 thingful
+//
+// Geolocation minimal js object mimic
+// https://dev.w3.org/geo/api/spec-source.html#position
+
+package engine
+
+type coordinates struct {
+	Latitude         float64 // specified in decimal degrees
+	Longitude        float64 // specified in decimal degrees
+	Accuracy         float64 // specified in meters
+	Altitude         float64 // specified in meters
+	AltitudeAccuracy float64 // specified in meters
+	Heading          float64 // specified in degrees
+	Speed            float64 // specified in m/s
+}
+
+type position struct {
+	Coords    coordinates
+	Timestamp int64 // represents the time when the position was acquired
+}
+
+func (p position) GetLat() float64 {
+	return p.Coords.Latitude
+}

--- a/engine/geolocation.go
+++ b/engine/geolocation.go
@@ -9,9 +9,6 @@ import (
 	"time"
 )
 
-// GeoLocation holds the geographic location
-var GeoLocation position
-
 type coordinates struct {
 	Latitude         float64 // specified in decimal degrees
 	Longitude        float64 // specified in decimal degrees
@@ -27,9 +24,8 @@ type position struct {
 	Timestamp int64 // represents the time in ms when the position was acquired
 }
 
-func (p *position) SetGeoLocation(lng, lat, acc float64) {
+func (p *position) setLocation(lat, lng float64) {
 	p.Timestamp = time.Now().UnixNano() / 1000000
 	p.Coords.Latitude = lat
 	p.Coords.Longitude = lng
-	p.Coords.Accuracy = acc
 }

--- a/engine/geolocation.go
+++ b/engine/geolocation.go
@@ -5,6 +5,13 @@
 
 package engine
 
+import (
+	"time"
+)
+
+// GeoLocation holds the geographic location
+var GeoLocation position
+
 type coordinates struct {
 	Latitude         float64 // specified in decimal degrees
 	Longitude        float64 // specified in decimal degrees
@@ -17,9 +24,12 @@ type coordinates struct {
 
 type position struct {
 	Coords    coordinates
-	Timestamp int64 // represents the time when the position was acquired
+	Timestamp int64 // represents the time in ms when the position was acquired
 }
 
-func (p position) GetLat() float64 {
-	return p.Coords.Latitude
+func (p *position) SetGeoLocation(lng, lat, acc float64) {
+	p.Timestamp = time.Now().UnixNano() / 1000000
+	p.Coords.Latitude = lat
+	p.Coords.Longitude = lng
+	p.Coords.Accuracy = acc
 }

--- a/examples/config/profile_script_geo.yaml
+++ b/examples/config/profile_script_geo.yaml
@@ -1,0 +1,26 @@
+---
+type: profile
+kind: script
+configuration:
+  # Profile name - a unique name for the profile
+  # Consider using a unique namespace of either an organisation or project
+  profile-name : thingful/device-test-geo
+  # Profile description
+  profile-description : blah blah blah
+  # Semanatic version for the profile
+  profile-version: 1.0.0-beta
+  # Name of the function to call
+  script-main: xxx
+  # Runtime to use - valid value 'javascript'
+  script-runtime: javascript
+  # Format of the message received.
+  # One of 'json', 'csv', 'xml', 'raw'
+  script-input: json
+  # Function to run - written in Javascript
+  # Can log via console.log
+  # Must return an object
+  script-contents: >
+      function xxx ( input )
+      {
+        return Number(geolocation.Coords.Latitude).toString() + ',' +  Number(geolocation.Coords.Longitude).toString()
+      }

--- a/examples/config/profile_script_geo.yaml
+++ b/examples/config/profile_script_geo.yaml
@@ -22,5 +22,5 @@ configuration:
   script-contents: >
       function xxx ( input )
       {
-        return Number(geolocation.Coords.Latitude).toString() + ',' +  Number(geolocation.Coords.Longitude).toString()
+        return geolocation.Coords.Latitude + ',' +  geolocation.Coords.Longitude
       }

--- a/examples/server_config/config.yaml
+++ b/examples/server_config/config.yaml
@@ -9,3 +9,6 @@ data_impl: boltdb
 log_file: true
 log_path: custom_log.log
 sys_log: false
+geo_enabled: true
+geo_lat: 54.416333
+geo_lng: -4.36552

--- a/runtime/loop.go
+++ b/runtime/loop.go
@@ -19,9 +19,14 @@ func loop(ctx context.Context,
 	endpoints map[string]hub.Endpoint,
 	channel hub.Channel,
 	logger utils.Logger,
-	tags map[string]string) {
+	tags map[string]string,
+	options map[string]interface{}) {
 
 	scripter := engine.New(logger)
+	if options["geolocation"].(bool) {
+		scripter.SetGeoLocation(options["lat"].(float64), options["lng"].(float64))
+	}
+
 	// ensure the map for the Statistics.Sent is set up correctly
 	for k, _ := range endpoints {
 		p.Statistics.Sent[k] = &proto.Counters{}

--- a/runtime/loop.go
+++ b/runtime/loop.go
@@ -20,11 +20,11 @@ func loop(ctx context.Context,
 	channel hub.Channel,
 	logger utils.Logger,
 	tags map[string]string,
-	options map[string]interface{}) {
+	options Options) {
 
 	scripter := engine.New(logger)
-	if options["geolocation"].(bool) {
-		scripter.SetGeoLocation(options["lat"].(float64), options["lng"].(float64))
+	if options.GeoEnabled {
+		scripter.SetGeoLocation(options.GeoLat, options.GeoLng)
 	}
 
 	// ensure the map for the Statistics.Sent is set up correctly

--- a/runtime/loop_test.go
+++ b/runtime/loop_test.go
@@ -41,8 +41,8 @@ func TestLoopCancelledAndPipeStoppedOnContextDone(t *testing.T) {
 
 	wg.Add(1)
 
-	options := make(map[string]interface{})
-	options["geolocation"] = false
+	options := Options{}
+	options.GeoEnabled = false
 
 	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 	closer()
@@ -76,8 +76,8 @@ func TestStatisticsOnChannelError(t *testing.T) {
 
 	pipe := newRuntimePipe(store.Pipe{})
 
-	options := make(map[string]interface{})
-	options["geolocation"] = false
+	options := Options{}
+	options.GeoEnabled = false
 
 	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 
@@ -133,8 +133,8 @@ func TestStatisticsOnChannelOut(t *testing.T) {
 		},
 	}
 
-	options := make(map[string]interface{})
-	options["geolocation"] = false
+	options := Options{}
+	options.GeoEnabled = false
 
 	go loop(ctx, pipe, nil, endpoints, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 

--- a/runtime/loop_test.go
+++ b/runtime/loop_test.go
@@ -41,7 +41,10 @@ func TestLoopCancelledAndPipeStoppedOnContextDone(t *testing.T) {
 
 	wg.Add(1)
 
-	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{})
+	options := make(map[string]interface{})
+	options["geolocation"] = false
+
+	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 	closer()
 
 	wg.Wait()
@@ -73,7 +76,10 @@ func TestStatisticsOnChannelError(t *testing.T) {
 
 	pipe := newRuntimePipe(store.Pipe{})
 
-	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{})
+	options := make(map[string]interface{})
+	options["geolocation"] = false
+
+	go loop(ctx, pipe, nil, map[string]hub.Endpoint{}, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 
 	errorChannel <- errors.New("boo!")
 
@@ -127,7 +133,10 @@ func TestStatisticsOnChannelOut(t *testing.T) {
 		},
 	}
 
-	go loop(ctx, pipe, nil, endpoints, mock, utils.NewNoOpLogger(), map[string]string{})
+	options := make(map[string]interface{})
+	options["geolocation"] = false
+
+	go loop(ctx, pipe, nil, endpoints, mock, utils.NewNoOpLogger(), map[string]string{}, options)
 
 	message := hub.Message{
 		Payload:  []byte("hello"),

--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -25,6 +25,7 @@ type Manager struct {
 	sync.RWMutex
 	register *registry.Registry
 	logger   utils.Logger
+	options  map[string]interface{}
 }
 
 // pipe holds runtime state information including various counters
@@ -69,7 +70,8 @@ type PipePredicate func(*Pipe) bool
 func NewEndpointManager(ctx context.Context,
 	repository *store.Repository,
 	registry *registry.Registry,
-	logger utils.Logger) (*Manager, error) {
+	logger utils.Logger,
+	options map[string]interface{}) (*Manager, error) {
 
 	// load any existing pipes from the database to
 	// serve as the initial running state
@@ -90,6 +92,7 @@ func NewEndpointManager(ctx context.Context,
 		ctx:        ctx,
 		register:   registry,
 		logger:     logger,
+		options:    options,
 	}, nil
 }
 
@@ -134,7 +137,7 @@ func (m *Manager) Start() error {
 
 			pp := m.pipes[n]
 
-			go loop(ctx, pp, listener, endpoints, channel, m.logger, p.Tags)
+			go loop(ctx, pp, listener, endpoints, channel, m.logger, p.Tags, m.options)
 			pp.cancel = cancel
 			pp.State = proto.Pipe_RUNNING
 			pp.Started = time.Now().UTC()

--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -17,6 +17,12 @@ import (
 	"github.com/thingful/device-hub/utils"
 )
 
+type Options struct {
+	GeoEnabled bool
+	GeoLat     float64
+	GeoLng     float64
+}
+
 // Manager holds the running instances of all the pipes
 type Manager struct {
 	Repository *store.Repository
@@ -25,7 +31,7 @@ type Manager struct {
 	sync.RWMutex
 	register *registry.Registry
 	logger   utils.Logger
-	options  map[string]interface{}
+	options  Options
 }
 
 // pipe holds runtime state information including various counters
@@ -71,7 +77,7 @@ func NewEndpointManager(ctx context.Context,
 	repository *store.Repository,
 	registry *registry.Registry,
 	logger utils.Logger,
-	options map[string]interface{}) (*Manager, error) {
+	options Options) (*Manager, error) {
 
 	// load any existing pipes from the database to
 	// serve as the initial running state

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,9 @@ type Options struct {
 	LogFile           bool
 	LogPath           string
 	Syslog            bool
+	GeoEnabled        bool
+	GeoLat            float64
+	GeoLng            float64
 }
 
 func Serve(options Options, manager *runtime.Manager) error {


### PR DESCRIPTION
This PR addresses #76 but instead of implementing a get_location() method, implements a pretty basic "goesque" mimic of Geolocation JS object.

```
JS Object: geolocation
    Integer Property: Timestamp
    JS Object: Coords
        Float Property: Latitude
        Float Property: Longitude
        Float Property: Accuracy
        Float Property: AltitudeAccuracy
        Float Property: Heading
        Float Property: Speed
```
In order to get latitude and longitude values configured on the server params:

```
geolocation.Coords.Latitude
geolocation.Coords.Longitude
```

The server's yaml config file now have the next new items:

```
geo_enabled: true
geo_lat: 54.416333
geo_lng: -4.36552
```

Also, JS engine has now a way to add new objects and functions to the JS runtime using maps

- AuxObjs for new Objects
- AuxFuncs for new functions

e.g Add a new Object:
```
	e := New(utils.NewNoOpLogger())

	pos := new(position)
	pos.Coords.Latitude = 54.416333
	pos.Coords.Longitude = -4.36552

	e.AuxObjs["geolocation"] = pos
```