### PR TITLE
implement hash of messages for integrity checking

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -38,6 +38,7 @@ Other measures that would normally be taken to secure a server should still be i
 Message Integrity
 ===============
 Every Message contains a metadata field with the payload's hash string(SHA2-256) to verify the message integrity. 
+```
 {
     "payload": "eyJteS12YWx1ZSI6IGZhbHNlfQ==",
     "output": "54.416333,54.416333",
@@ -57,3 +58,4 @@ Every Message contains a metadata field with the payload's hash string(SHA2-256)
         "sha256:sum": "96172efad6f5d1c1647ffe867e5b4302fd54e3b2593177dd22db126466b603e1"
     }
 }
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -34,3 +34,26 @@ It is therefore very important that you ensure the private keys are kept secure;
 When copying certificates and private keys as part of the device-hub installation process, the files must be copied using a secure and encrypted transfer medium such as SSH, SCP or SFTP.
 
 Other measures that would normally be taken to secure a server should still be implemented; device-hub is not a full server stack and its security layer does not prevent your server being hacked, rather it mitigates the likelihood of device-hub services being used as a vector to do so.
+
+Message Integrity
+===============
+Every Message contains a metadata field with the payload's hash string(SHA2-256) to verify the message integrity. 
+{
+    "payload": "eyJteS12YWx1ZSI6IGZhbHNlfQ==",
+    "output": "54.416333,54.416333",
+    "schema": {},
+    "metadata": {
+        "engine:ended-at": "2017-07-31T19:57:18.373418928Z",
+        "engine:ok": true,
+        "engine:started-at": "2017-07-31T19:57:18.372242549Z",
+        "host": "Christians-MBP.home",
+        "message:id": "b5von7m799i2ucmvrmcg",
+        "pipe:protocol": "HTTP",
+        "pipe:received-at": "2017-07-31T19:57:18.372224257Z",
+        "pipe:uri": "/a",
+        "profile:name": "thingful/device-geo",
+        "profile:version": "1.0.0-beta",
+        "runtime:version": "5ca4ba",
+        "sha256:sum": "96172efad6f5d1c1647ffe867e5b4302fd54e3b2593177dd22db126466b603e1"
+    }
+}

--- a/listener/message.go
+++ b/listener/message.go
@@ -21,7 +21,7 @@ func newHubMessage(payload []byte, protocol, uri string) hub.Message {
 	m := hub.Message{
 		Payload: payload,
 		Metadata: map[string]interface{}{
-			hub.SHA256_SUM:         "",
+			hub.SHA256_SUM:         "not calculated",
 			hub.PIPE_URI_NAME_KEY:  uri,
 			hub.PIPE_PROTOCOL_KEY:  protocol,
 			hub.PIPE_TIMESTAMP_KEY: time.Now().UTC(),

--- a/listener/message.go
+++ b/listener/message.go
@@ -3,12 +3,8 @@
 package listener
 
 import (
-	"encoding/hex"
-	"log"
 	"os"
 	"time"
-
-	"crypto/sha256"
 
 	"github.com/rs/xid"
 
@@ -21,17 +17,11 @@ func newHubMessage(payload []byte, protocol, uri string) hub.Message {
 	if err != nil {
 		host = "UNKNOWN"
 	}
-	hasher := sha256.New()
-	if _, err := hasher.Write(payload); err != nil {
-		log.Printf("failed to write to hash in message: %s", err.Error())
-	}
-
-	hash := hex.EncodeToString(hasher.Sum(nil))
 
 	m := hub.Message{
 		Payload: payload,
 		Metadata: map[string]interface{}{
-			hub.SHA256_SUM:         hash,
+			hub.SHA256_SUM:         "",
 			hub.PIPE_URI_NAME_KEY:  uri,
 			hub.PIPE_PROTOCOL_KEY:  protocol,
 			hub.PIPE_TIMESTAMP_KEY: time.Now().UTC(),

--- a/listener/message.go
+++ b/listener/message.go
@@ -3,8 +3,12 @@
 package listener
 
 import (
+	"encoding/hex"
+	"log"
 	"os"
 	"time"
+
+	"crypto/sha256"
 
 	"github.com/rs/xid"
 
@@ -14,14 +18,20 @@ import (
 func newHubMessage(payload []byte, protocol, uri string) hub.Message {
 
 	host, err := os.Hostname()
-
 	if err != nil {
 		host = "UNKNOWN"
 	}
+	hasher := sha256.New()
+	if _, err := hasher.Write(payload); err != nil {
+		log.Printf("failed to write to hash in message: %s", err.Error())
+	}
+
+	hash := hex.EncodeToString(hasher.Sum(nil))
 
 	m := hub.Message{
 		Payload: payload,
 		Metadata: map[string]interface{}{
+			hub.SHA256_SUM:         hash,
 			hub.PIPE_URI_NAME_KEY:  uri,
 			hub.PIPE_PROTOCOL_KEY:  protocol,
 			hub.PIPE_TIMESTAMP_KEY: time.Now().UTC(),

--- a/metadata.go
+++ b/metadata.go
@@ -7,6 +7,8 @@ const (
 
 	MESSAGE_ID = "message:id"
 
+	SHA256_SUM = "sha256:sum"
+
 	ENGINE_TIMESTAMP_START_KEY = "engine:started-at"
 	ENGINE_TIMESTAMP_END_KEY   = "engine:ended-at"
 	ENGINE_OK_KEY              = "engine:ok"

--- a/runtime/loop.go
+++ b/runtime/loop.go
@@ -4,6 +4,9 @@ package runtime
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"time"
 
 	hub "github.com/thingful/device-hub"
@@ -82,6 +85,15 @@ func loop(ctx context.Context,
 			output.Tags = tags
 
 			output.Schema = p.Profile.Schema
+
+			// Hashing the message, if an error occurs SHA256_SUM will be ""
+			if m, err := json.Marshal(output); err == nil {
+				hasher := sha256.New()
+				if _, err := hasher.Write(m); err == nil {
+					hash := hex.EncodeToString(hasher.Sum(nil))
+					output.Metadata[hub.SHA256_SUM] = hash
+				}
+			}
 
 			for k, _ := range endpoints {
 


### PR DESCRIPTION
This PR addresses #75 using sha2-256 to hash messages:

```
{
    "payload": "eyJteS12YWx1ZSI6IGZhbHNlfQ==",
    "output": "54.416333,54.416333",
    "schema": {},
    "metadata": {
        "engine:ended-at": "2017-07-31T19:57:18.373418928Z",
        "engine:ok": true,
        "engine:started-at": "2017-07-31T19:57:18.372242549Z",
        "host": "Christians-MBP.home",
        "message:id": "b5von7m799i2ucmvrmcg",
        "pipe:protocol": "HTTP",
        "pipe:received-at": "2017-07-31T19:57:18.372224257Z",
        "pipe:uri": "/a",
        "profile:name": "thingful/device-geo",
        "profile:version": "1.0.0-beta",
        "runtime:version": "5ca4ba",
        "sha256:sum": "96172efad6f5d1c1647ffe867e5b4302fd54e3b2593177dd22db126466b603e1"
    }
}
```